### PR TITLE
Prevent duplicate image upload on post creation / edition

### DIFF
--- a/iq_hootsuite_publisher.install
+++ b/iq_hootsuite_publisher.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * 
+ * Custom hooks for iq_hootsuite_publisher installation / update. 
+ */
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Add hootsuite id field to file entity.
+ */
+function iq_hootsuite_publisher_update_9001() {
+  $field_storage = FieldStorageConfig::loadByName('file', 'field_hs_id');
+  if (empty($field_storage)) {
+    // Create the field storage definition.
+    FieldStorageConfig::create([
+      'field_name' => 'field_hs_id',
+      'entity_type' => 'file',
+      'type' => 'text',
+      'cardinality' => 1,
+    ])->save();
+
+    // Create the field instance.
+    FieldConfig::create([
+      'field_name' => 'field_hs_id',
+      'label' => 'Hootsuite ID',
+      'entity_type' => 'file',
+      'bundle' => 'file',
+      'required' => FALSE,
+    ])->save();
+  }
+}

--- a/src/Service/HootsuitePostManager.php
+++ b/src/Service/HootsuitePostManager.php
@@ -173,7 +173,7 @@ class HootsuitePostManager {
         if ($id) {
           $requestBody['media'] = [['id' => $id]];
         }
-        else if (($id = $this->uploadImage($image)) !== FALSE) {
+        elseif (($id = $this->uploadImage($image)) !== FALSE) {
           // Save the id to the file entity.
           $image->set('field_hs_id', $id);
           $image->save();

--- a/src/Service/HootsuitePostManager.php
+++ b/src/Service/HootsuitePostManager.php
@@ -174,6 +174,9 @@ class HootsuitePostManager {
           $requestBody['media'] = [['id' => $id]];
         }
         else if (($id = $this->uploadImage($image)) !== FALSE) {
+          // Save the id to the file entity.
+          $image->set('field_hs_id', $id);
+          $image->save();
           $requestBody['media'] = [['id' => $id]];
         }
         else {

--- a/src/Service/HootsuitePostManager.php
+++ b/src/Service/HootsuitePostManager.php
@@ -217,8 +217,11 @@ class HootsuitePostManager {
         ]
       );
       $this->messenger->addMessage(
-        'The post for @profile has been successfully scheduled.',
-        ['@profile' => $assignment->field_hs_profile_name->value]
+        $this->t('The post for @profile has been successfully scheduled.',
+          [
+            '@profile' => $assignment->field_hs_profile_name->value,
+          ]
+        )
       );
     }
     else {
@@ -230,8 +233,11 @@ class HootsuitePostManager {
          ]
        );
       $this->messenger->addWarning(
-        'Failed posting for @profile.',
-        ['@profile' => $assignment->field_hs_profile_name->value]
+        $this->t('Failed posting for @profile.',
+          [
+            '@profile' => $assignment->field_hs_profile_name->value,
+          ]
+        )
       );
     }
   }
@@ -262,8 +268,11 @@ class HootsuitePostManager {
         ]
       );
       $this->messenger->addMessage(
-       $this->t('Deleted post for @profile.'),
-        ['@profile' => $assignment->field_hs_profile_name->value]
+        $this->t('Deleted post for @profile.',
+          [
+            '@profile' => $assignment->field_hs_profile_name->value,
+          ]
+        )
       );
     }
   }

--- a/src/Service/HootsuitePostManager.php
+++ b/src/Service/HootsuitePostManager.php
@@ -19,6 +19,8 @@ use GuzzleHttp\RequestOptions;
  */
 class HootsuitePostManager {
 
+  use \Drupal\Core\StringTranslation\StringTranslationTrait;
+
   /**
    * The api client for hootsuite.
    *
@@ -140,6 +142,7 @@ class HootsuitePostManager {
     // Delete post from hootsuite if already exists.
     if (!$assignment->field_hs_post_id->isEmpty()) {
       $this->deletePost($assignment, TRUE);
+      $this->logger->notice($this->t('Deleted post @id on hootsuite', ['@id' => $assignment->field_hs_post_id->value]));
       $assignment->field_hs_post_id->value = NULL;
     }
 
@@ -168,6 +171,7 @@ class HootsuitePostManager {
           if (!empty($response)) {
             $media_data = json_decode($response, TRUE)['data'];
             $id = $media_data['id'];
+            $this->logger->notice($this->t('Retrieved image @id from hootsuite', ['@id' => $id]));
           }
         }
         if ($id) {
@@ -181,7 +185,7 @@ class HootsuitePostManager {
         }
         else {
           $this->messenger->addError(
-              t('Post for @profile has not been posted/changed on Hootsuite due to error on image processing.',
+             $this->t('Post for @profile has not been posted/changed on Hootsuite due to error on image processing.',
               ['@profile' => $assignment->field_hs_profile_name->value])
             );
           return;
@@ -206,7 +210,7 @@ class HootsuitePostManager {
       /** @var \Drupal\Core\Entity\Entity $entity */
       $assignment->save();
       $this->logger->notice(
-        t('Created post for @profile with id @id.'),
+       $this->t('Created post for @profile with id @id.'),
         [
           '@profile' => $assignment->field_hs_profile_name->value,
           '@id' => $assignment->field_hs_post_id->value,
@@ -218,6 +222,13 @@ class HootsuitePostManager {
       );
     }
     else {
+      $this->logger->notice(
+        $this->t('Fail creating post for @profile with id @id.'),
+         [
+           '@profile' => $assignment->field_hs_profile_name->value,
+           '@id' => $assignment->field_hs_post_id->value,
+         ]
+       );
       $this->messenger->addWarning(
         'Failed posting for @profile.',
         ['@profile' => $assignment->field_hs_profile_name->value]
@@ -244,14 +255,14 @@ class HootsuitePostManager {
     $this->hootsuiteClient->connect('delete', $url);
     if (!$update) {
       $this->logger->notice(
-        t('Deleted post for @profile with id @id.'),
+       $this->t('Deleted post for @profile with id @id.'),
         [
           '@profile' => $assignment->field_hs_profile_name->value,
           '@id' => $assignment->field_hs_post_id->value,
         ]
       );
       $this->messenger->addMessage(
-        t('Deleted post for @profile.'),
+       $this->t('Deleted post for @profile.'),
         ['@profile' => $assignment->field_hs_profile_name->value]
       );
     }
@@ -287,7 +298,7 @@ class HootsuitePostManager {
       }
       else {
         $this->messenger->addError(
-          t('Post for @profile has not been posted/changed on Hootsuite due to missing board id.',
+         $this->t('Post for @profile has not been posted/changed on Hootsuite due to missing board id.',
          ['@profile' => $assignment->field_hs_profile_name->value])
         );
         return NULL;
@@ -304,6 +315,12 @@ class HootsuitePostManager {
    */
   public function uploadImage(File $image) {
     if (!empty($this->images[$image->id()])) {
+      $this->logger->notice(
+        $this->t('Image @id already exists.'),
+         [
+           '@id' => $image->id(),
+         ]
+       );
       return $this->images[$image->id()];
     }
     else {
@@ -327,8 +344,20 @@ class HootsuitePostManager {
       'mimeType' => $image->getMimeType(),
       'sizeBytes' => filesize($image->getFileUri()),
     ];
+    $this->logger->notice(
+      $this->t('Posting Image @id to hootsuite.'),
+      [
+        '@id' => $image->id(),
+      ]
+    );
     $result = $this->hootsuiteClient->connect('post', $this->config->get('url_post_media_endpoint'), NULL, $body);
     if (empty($result)) {
+      $this->logger->notice(
+        $this->t('Image @id could not be created on hootsuite.'),
+         [
+           '@id' => $image->id(),
+         ]
+       );
       return FALSE;
     }
     $data = json_decode($result, TRUE)['data'];
@@ -376,6 +405,13 @@ class HootsuitePostManager {
       return TRUE;
     }
     catch (\Exception $e) {
+      $this->logger->notice(
+        $this->t('Error when uploading image @url to aws. Message: @message'),
+         [
+           '@id' => $image->id(),
+           '@message' => $e->getMessage(),
+         ]
+       );
       $this->messenger->addMessage($e->getMessage());
       return FALSE;
     }


### PR DESCRIPTION
This PR adds a check when posting a message to hootsuite, to see if the linked media image was already uploaded.

To do so, this PR:

- adds a new field on file entity (field_hs_id) to store hootsuite id of the media into the Drupal file entity
- Add a check on the postMessage call of the HootSuitePostManager to verify that the associated media image is not already uploaded

@To Do / To Discuss
The postMessage method delete the existing post in hootsuite on every post update... I can't find why, and I would suggest to rather fetch existing post and edit it